### PR TITLE
feat: use singleflight for proxy.Manifest and proxy.Blob requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,6 +93,16 @@ jobs:
         with:
           files: ./src/github.com/groq/harbor/profile.cov
           flags: unittests
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: apitest-db-outputs
+          path: |
+            /drone/output.xml
+            /drone/log.html
+            /drone/report.html
+          if-no-files-found: ignore
 
   APITEST_DB:
     env:
@@ -148,6 +158,16 @@ jobs:
           df -h
           bash ./tests/showtime.sh ./tests/ci/api_run.sh DB $IP
           df -h
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: apitest-db-outputs
+          path: |
+            /drone/output.xml
+            /drone/log.html
+            /drone/report.html
+          if-no-files-found: ignore
 
   APITEST_DB_PROXY_CACHE:
     env:
@@ -203,6 +223,16 @@ jobs:
           df -h
           bash ./tests/showtime.sh ./tests/ci/api_run.sh PROXY_CACHE $IP
           df -h
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: apitest-db-outputs
+          path: |
+            /drone/output.xml
+            /drone/log.html
+            /drone/report.html
+          if-no-files-found: ignore
 
   APITEST_LDAP:
     env:
@@ -256,6 +286,16 @@ jobs:
           cd src/github.com/groq/harbor
           bash ./tests/showtime.sh ./tests/ci/api_run.sh LDAP $IP
           df -h
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: apitest-db-outputs
+          path: |
+            /drone/output.xml
+            /drone/log.html
+            /drone/report.html
+          if-no-files-found: ignore
 
   OFFLINE:
     env:
@@ -308,6 +348,16 @@ jobs:
           cd src/github.com/groq/harbor
           bash ./tests/showtime.sh ./tests/ci/distro_installer.sh
           df -h
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: apitest-db-outputs
+          path: |
+            /drone/output.xml
+            /drone/log.html
+            /drone/report.html
+          if-no-files-found: ignore
 
   UI_UT:
     env:
@@ -335,3 +385,13 @@ jobs:
         with:
           files: ./src/github.com/groq/harbor/src/portal/coverage/lcov.info
           flags: unittests
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: apitest-db-outputs
+          path: |
+            /drone/output.xml
+            /drone/log.html
+            /drone/report.html
+          if-no-files-found: ignore

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    types: [labeled]
 
 env:
   REGISTRY: ghcr.io
@@ -14,13 +16,20 @@ jobs:
     permissions:
       contents: write
       packages: write
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-release'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup env
         run: |
-          echo "CUR_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
-          echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
-          echo "PRERELEASE=$(echo ${{ github.ref_name }} | grep -q 'rc\|alpha\|beta' && echo 'true' || echo 'false')" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "CUR_TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
+            echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "CUR_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
+            echo "PRERELEASE=$(echo ${{ github.ref_name }} | grep -q 'rc\|alpha\|beta' && echo 'true' || echo 'false')" >> $GITHUB_ENV
+          fi
           
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/GROQ.md
+++ b/GROQ.md
@@ -23,4 +23,4 @@ We saw it important to maintain a separate fork of Harbor to handle a couple of 
 
 1. We need to add support for Google GAR and GCP Workload Identity Federation ([upstream PR](https://github.com/goharbor/harbor/pull/22091)).
 
-2. We're concerned that Harbor does not currenty coalesce concurrent remote requests for the same image reference (upstream PR WIP). 
+2. We're concerned that Harbor does not currenty coalesce concurrent remote requests for the same image reference (upstream PR WIP). As such, we've introduced a `ENABLE_ASYNC_LOCAL_CACHING` setting, which forces concurrent requests for the same artifact to queue and wait for a single remote registry request. This incurs a slight performance penalty on the initial pull, but is much more bandwidth efficient.

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -217,6 +217,9 @@ const (
 	AuditLogForwardEndpoint = "audit_log_forward_endpoint"
 	// SkipAuditLogDatabase skip to log audit log in database
 	SkipAuditLogDatabase = "skip_audit_log_database"
+	// EnableAsyncLocalCaching indicate whether enable async local caching for proxy cache blobs.
+	EnableAsyncLocalCaching = "enable_async_local_caching"
+
 	// MaxAuditRetentionHour allowed in audit log purge
 	MaxAuditRetentionHour = 240000
 	// ScannerSkipUpdatePullTime

--- a/src/controller/proxy/controller_test.go
+++ b/src/controller/proxy/controller_test.go
@@ -15,20 +15,30 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/docker/distribution"
+	schema1 "github.com/docker/distribution/manifest/schema1"
+	_ "github.com/jackc/pgx/v4/stdlib" // registry pgx driver
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/blob"
 	"github.com/goharbor/harbor/src/lib"
 	_ "github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/pkg/config/inmemory"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	testproxy "github.com/goharbor/harbor/src/testing/controller/proxy"
 )
@@ -61,7 +71,21 @@ func (l *localInterfaceMock) BlobExist(ctx context.Context, art lib.ArtifactInfo
 }
 
 func (l *localInterfaceMock) PushBlob(localRepo string, desc distribution.Descriptor, bReader io.ReadCloser) error {
-	panic("implement me")
+	args := l.Called(localRepo, desc, bReader)
+	return args.Error(0)
+}
+
+func (l *localInterfaceMock) PullBlob(localRepo string, digest digest.Digest) (int64, io.ReadCloser, error) {
+	args := l.Called(localRepo, digest)
+	var size int64
+	var bReader io.ReadCloser
+	if args.Get(0) != nil {
+		size = args.Get(0).(int64)
+	}
+	if args.Get(1) != nil {
+		bReader = io.NopCloser(bytes.NewReader(args.Get(1).([]byte)))
+	}
+	return size, bReader, args.Error(2)
 }
 
 func (l *localInterfaceMock) PushManifest(repo string, tag string, manifest distribution.Manifest) error {
@@ -82,13 +106,40 @@ func (l *localInterfaceMock) DeleteManifest(repo, ref string) {
 
 type proxyControllerTestSuite struct {
 	suite.Suite
+	cfg    config.Manager
 	local  *localInterfaceMock
 	remote *testproxy.RemoteInterface
 	ctr    Controller
 	proj   *proModels.Project
 }
 
+func (p *proxyControllerTestSuite) SetupSuite() {
+	// Register a global in memory config manager for testing
+	config.Register(common.InMemoryCfgManager, inmemory.NewInMemoryManager())
+	config.DefaultCfgManager = common.InMemoryCfgManager
+
+	// This doesn't really do anything other than allow us to run `orm.Copy` in the background
+	// prior to submitting events that depend on a database connection. The database connection
+	// is not actually used in these proxy controller tests.
+	if err := orm.RegisterDriver("pgx", orm.DRPostgres); err != nil {
+		p.T().Fatalf("Failed to register test database driver: %v", err)
+	}
+	db, _, err := sqlmock.New()
+	if err != nil {
+		p.T().Fatalf("Failed to create sqlmock: %v", err)
+	}
+	if err := orm.AddAliasWthDB("default", "pgx", db); err != nil {
+		p.T().Fatalf("Failed to add alias with db: %v", err)
+	}
+}
+
 func (p *proxyControllerTestSuite) SetupTest() {
+	cfg, err := config.GetManager(config.DefaultCfgManager)
+	if err != nil {
+		p.T().Fatalf("Failed to get config manager: %v", err)
+	}
+
+	p.cfg = cfg
 	p.local = &localInterfaceMock{}
 	p.remote = &testproxy.RemoteInterface{}
 	p.proj = &proModels.Project{RegistryID: 1}
@@ -162,6 +213,7 @@ func (p *proxyControllerTestSuite) TestUseLocalBlob_True() {
 	dig := "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
 	art := lib.ArtifactInfo{Repository: "library/hello-world", Digest: dig}
 	p.local.On("BlobExist", mock.Anything, mock.Anything).Return(true, nil)
+	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	result := p.ctr.UseLocalBlob(ctx, art)
 	p.Assert().True(result)
 }
@@ -171,8 +223,188 @@ func (p *proxyControllerTestSuite) TestUseLocalBlob_False() {
 	dig := "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
 	art := lib.ArtifactInfo{Repository: "library/hello-world", Digest: dig}
 	p.local.On("BlobExist", mock.Anything, mock.Anything).Return(false, nil)
+	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	result := p.ctr.UseLocalBlob(ctx, art)
 	p.Assert().False(result)
+}
+
+func (p *proxyControllerTestSuite) TestUseLocalManifest_EnsureSingleRemoteRequest() {
+	ctx := context.Background()
+	artInfo := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		ProjectName: "library",
+		Digest:      "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+	}
+	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(nil, nil)
+
+	// force a not_found error
+	p.remote.On("ManifestExist", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		// wait for requests to queue up
+		time.Sleep(10 * time.Millisecond)
+	}).Return(false, nil, nil).Once()
+
+	// run 10 concurrent requests
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := p.ctr.UseLocalManifest(ctx, artInfo, p.remote)
+			p.Assert().True(errors.IsNotFoundErr(err))
+		}()
+	}
+
+	wg.Wait()
+
+	// expect only one remote request
+	p.remote.AssertExpectations(p.T())
+}
+
+func (p *proxyControllerTestSuite) TestProxyManifest_EnsureSingleRemoteRequest() {
+	ctx := context.Background()
+	artInfo := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		ProjectName: "library",
+		Digest:      "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+	}
+	man := &schema1.SignedManifest{
+		Manifest: schema1.Manifest{
+			Name: "library/hello-world",
+			Tag:  "latest",
+		},
+	}
+
+	// Set up mock expectations for methods called by background goroutines
+	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(nil, nil)
+
+	// return a valid manifest
+	p.remote.On("Manifest", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		// wait for requests to queue up
+		time.Sleep(10 * time.Millisecond)
+	}).Return(man, "", nil).Once()
+
+	// run 10 concurrent requests
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			actualMan, err := p.ctr.ProxyManifest(ctx, artInfo, p.remote)
+			p.Assert().Nil(err)
+			p.Assert().Equal(man, actualMan)
+		}()
+	}
+
+	wg.Wait()
+
+	// expect only one remote request
+	p.remote.AssertExpectations(p.T())
+}
+
+func (p *proxyControllerTestSuite) TestHeadManifest_EnsureSingleRemoteRequest() {
+	ctx := context.Background()
+	dig := "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
+	artInfo := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		ProjectName: "library",
+		Digest:      dig,
+	}
+
+	// return a valid manifest
+	p.remote.On("ManifestExist", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		time.Sleep(10 * time.Millisecond)
+	}).Return(true, &distribution.Descriptor{Digest: digest.Digest(dig)}, nil).Once()
+
+	// run 10 concurrent requests
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			exists, desc, err := p.ctr.HeadManifest(ctx, artInfo, p.remote)
+			p.Assert().Nil(err)
+			p.Assert().True(exists)
+			p.Assert().Equal(digest.Digest(dig), desc.Digest)
+		}()
+	}
+
+	wg.Wait()
+
+	// expect only one remote request
+	p.remote.AssertExpectations(p.T())
+}
+
+func (p *proxyControllerTestSuite) TestProxyBlob_EnableAsyncLocalCaching_True() {
+	p.cfg.Set(context.Background(), common.EnableAsyncLocalCaching, true)
+
+	enabled := config.EnableAsyncLocalCaching()
+	p.Assert().True(enabled)
+
+	// expect blob to be pulled from remote
+	p.local.On("PushBlob", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	p.remote.On("BlobReader", mock.Anything, mock.Anything).Return(int64(100), io.NopCloser(bytes.NewReader([]byte("test"))), nil)
+
+	size, bReader, err := p.ctr.ProxyBlob(
+		context.Background(),
+		&proModels.Project{},
+		lib.ArtifactInfo{
+			Repository: "library/hello-world",
+			Digest:     "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+		},
+		p.remote,
+	)
+	p.Assert().Nil(err)
+	p.Assert().Equal(int64(100), size)
+	blob, _ := io.ReadAll(bReader)
+	p.Assert().Equal([]byte("test"), blob)
+
+	// expect blob to be pushed to local in background eventually
+	p.Eventually(func() bool {
+		return p.local.AssertExpectations(p.T())
+	}, 1*time.Second, 100*time.Millisecond, "expecting PushBlob to be called once")
+}
+
+func (p *proxyControllerTestSuite) TestProxyBlob_EnableAsyncLocalCaching_False() {
+	p.cfg.Set(context.Background(), common.EnableAsyncLocalCaching, false)
+
+	enabled := config.EnableAsyncLocalCaching()
+	p.Assert().False(enabled)
+
+	// only expect remote requests to be made once
+	p.local.On("BlobExist", mock.Anything, mock.Anything).Return(false, nil)
+	p.local.On("PullBlob", mock.Anything, mock.Anything).Return(int64(100), []byte("test"), nil)
+	p.local.On("PushBlob", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	p.remote.On("BlobReader", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		// wait for requests to queue up
+		time.Sleep(10 * time.Millisecond)
+	}).Return(int64(100), io.NopCloser(bytes.NewReader([]byte("test"))), nil).Once()
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			size, bReader, err := p.ctr.ProxyBlob(
+				context.Background(),
+				&proModels.Project{},
+				lib.ArtifactInfo{
+					Repository: "library/hello-world",
+					Digest:     "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+				},
+				p.remote,
+			)
+			p.Assert().Nil(err)
+			p.Assert().Equal(int64(100), size)
+
+			blob, _ := io.ReadAll(bReader)
+			p.Assert().Equal([]byte("test"), blob)
+		}()
+	}
+
+	wg.Wait()
+
+	// expect only one remote request
+	p.remote.AssertExpectations(p.T())
 }
 
 func TestProxyControllerTestSuite(t *testing.T) {

--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/docker/distribution"
+	"github.com/opencontainers/go-digest"
 
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/event/metadata"
@@ -43,6 +44,8 @@ type localInterface interface {
 	GetManifest(ctx context.Context, art lib.ArtifactInfo) (*artifact.Artifact, error)
 	// PushBlob push blob to local repo
 	PushBlob(localRepo string, desc distribution.Descriptor, bReader io.ReadCloser) error
+	// PullBlob pull blob from local repo
+	PullBlob(localRepo string, digest digest.Digest) (int64, io.ReadCloser, error)
 	// PushManifest push manifest to local repo, ref can be digest or tag
 	PushManifest(repo string, ref string, manifest distribution.Manifest) error
 	// CheckDependencies check if the manifest's dependency is ready
@@ -107,6 +110,11 @@ func (l *localHelper) PushBlob(localRepo string, desc distribution.Descriptor, b
 	defer inflightChecker.removeRequest(artName)
 	err := l.registry.PushBlob(localRepo, ref, desc.Size, bReader)
 	return err
+}
+
+func (l *localHelper) PullBlob(localRepo string, digest digest.Digest) (int64, io.ReadCloser, error) {
+	ref := string(digest)
+	return l.registry.PullBlob(localRepo, ref)
 }
 
 func (l *localHelper) PushManifest(repo string, ref string, manifest distribution.Manifest) error {

--- a/src/go.mod
+++ b/src/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Unknwon/goconfig v0.0.0-20160216183935-5f601ca6ef4d // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -42,6 +42,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudNativeAI/model-spec v0.0.3 h1:5mvgFQ+3pyupzxYjtV5XAeg9zRe6+46pLPBFNHlOrqE=
 github.com/CloudNativeAI/model-spec v0.0.3/go.mod h1:3U/4zubBfbUkW59ATSg41HnkYyKrKUcKFH/cVdoPQnk=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/FZambia/sentinel v1.1.0 h1:qrCBfxc8SvJihYNjBWgwUI93ZCvFe/PJIPTHKmlp8a8=
 github.com/FZambia/sentinel v1.1.0/go.mod h1:ytL1Am/RLlAoAXG6Kj5LNuw/TRRQrv2rt2FT26vP5gI=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
@@ -369,6 +371,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -185,6 +185,7 @@ var (
 
 		{Name: common.CacheEnabled, Scope: SystemScope, Group: BasicGroup, EnvKey: "CACHE_ENABLED", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `Enable cache`},
 		{Name: common.CacheExpireHours, Scope: SystemScope, Group: BasicGroup, EnvKey: "CACHE_EXPIRE_HOURS", DefaultValue: "24", ItemType: &IntType{}, Editable: false, Description: `The expire hours for cache`},
+		{Name: common.EnableAsyncLocalCaching, Scope: SystemScope, Group: BasicGroup, EnvKey: "ENABLE_ASYNC_LOCAL_CACHING", DefaultValue: "true", ItemType: &BoolType{}, Editable: false, Description: `Enable async local caching for proxy cache blobs`},
 
 		{Name: common.GDPRDeleteUser, Scope: SystemScope, Group: GDPRGroup, EnvKey: "GDPR_DELETE_USER", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag indicates if a user should be deleted compliant with GDPR.`},
 		{Name: common.GDPRAuditLogs, Scope: SystemScope, Group: GDPRGroup, EnvKey: "GDPR_AUDIT_LOGS", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag indicates if an audit logs of a deleted user should be GDPR compliant.`},

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -251,6 +251,16 @@ func ScannerRobotPrefix(ctx context.Context) string {
 	return os.Getenv("ROBOT_SCANNER_NAME_PREFIX")
 }
 
+// EnableAsyncLocalCaching returns whether enable async local caching for proxy cache blobs.
+func EnableAsyncLocalCaching() bool {
+	if DefaultMgr() != nil {
+		return DefaultMgr().Get(backgroundCtx, common.EnableAsyncLocalCaching).GetBool()
+	}
+	// backoff read from env, default to true to preserve current behavior
+	env := os.Getenv("ENABLE_ASYNC_LOCAL_CACHING")
+	return env == "" || env == "true"
+}
+
 // Database returns database settings
 func Database() (*models.Database, error) {
 	database := &models.Database{}

--- a/src/lib/metric/collector.go
+++ b/src/lib/metric/collector.go
@@ -26,6 +26,7 @@ func RegisterCollectors() {
 		TotalInFlightGauge,
 		TotalReqCnt,
 		TotalReqDurSummary,
+		TotalRemoteRegistryReqCnt,
 	}...)
 }
 
@@ -61,4 +62,15 @@ var (
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"method", "operation"})
+
+	// TotalRemoteReqCnt tracks the number of remote requests by method, path, and registry
+	TotalRemoteRegistryReqCnt = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: os.Getenv(NamespaceEnvKey),
+			Subsystem: os.Getenv(SubsystemEnvKey),
+			Name:      "remote_registry_request_total",
+			Help:      "Total number of remote registry requests",
+		},
+		[]string{"operation", "registry_name", "success"},
+	)
 )

--- a/src/server/middleware/repoproxy/tag.go
+++ b/src/server/middleware/repoproxy/tag.go
@@ -26,6 +26,7 @@ import (
 	libhttp "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg/reg"
 	"github.com/goharbor/harbor/src/server/middleware"
 	"github.com/goharbor/harbor/src/server/registry/util"
 )
@@ -69,7 +70,7 @@ func TagsListMiddleware() func(http.Handler) http.Handler {
 			util.SendListTagsResponse(w, r, tags)
 		}()
 
-		remote, err := proxy.NewRemoteHelper(ctx, p.RegistryID, proxy.WithSpeed(p.ProxyCacheSpeed()))
+		remote, err := proxy.NewRemoteHelper(ctx, p.RegistryID, reg.Mgr, proxy.WithSpeed(p.ProxyCacheSpeed()))
 		if err != nil {
 			logger.Warningf("failed to get remote interface, error: %v, fallback to local tags", err)
 			return


### PR DESCRIPTION
Uses the singleflight package to de-duplicate remote `Manifest` and `Blob` request at the proxy controller.