### PR TITLE
feat: make `PULL_*` env vars actually work

### DIFF
--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -179,9 +179,9 @@ var (
 		{Name: common.TraceOtelInsecure, Scope: SystemScope, Group: BasicGroup, EnvKey: "TRACE_OTEL_INSECURE", DefaultValue: "", ItemType: &BoolType{}, Editable: false, Description: `The insecure of the Otel`},
 		{Name: common.TraceOtelTimeout, Scope: SystemScope, Group: BasicGroup, EnvKey: "TRACE_OTEL_TIMEOUT", DefaultValue: "", ItemType: &IntType{}, Editable: false, Description: `The timeout of the Otel`},
 
-		{Name: common.PullTimeUpdateDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_TIME_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull time is disable for pull request.`},
-		{Name: common.PullCountUpdateDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_COUNT_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull count is disable for pull request.`},
-		{Name: common.PullAuditLogDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_AUDIT_LOG_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull audit log is disable for pull request.`},
+		{Name: common.PullTimeUpdateDisable, Scope: SystemScope, Group: BasicGroup, EnvKey: "PULL_TIME_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull time is disable for pull request.`},
+		{Name: common.PullCountUpdateDisable, Scope: SystemScope, Group: BasicGroup, EnvKey: "PULL_COUNT_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull count is disable for pull request.`},
+		{Name: common.PullAuditLogDisable, Scope: SystemScope, Group: BasicGroup, EnvKey: "PULL_AUDIT_LOG_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull audit log is disable for pull request.`},
 
 		{Name: common.CacheEnabled, Scope: SystemScope, Group: BasicGroup, EnvKey: "CACHE_ENABLED", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `Enable cache`},
 		{Name: common.CacheExpireHours, Scope: SystemScope, Group: BasicGroup, EnvKey: "CACHE_EXPIRE_HOURS", DefaultValue: "24", ItemType: &IntType{}, Editable: false, Description: `The expire hours for cache`},


### PR DESCRIPTION
Allow `PULL_TIME_UPDATE_DISABLE`, `PULL_COUNT_UPDATE_DISABLE`, and `PULL_AUDIT_LOG_DISABLE` to actually be set via env vars.

Before:
```
jstrain@jstrain:~/code/harbor$ sudo docker compose -f make/docker-compose.yml exec core env | grep PULL
jstrain@jstrain:~/code/harbor$ crane pull localhost:8080/dockerhub/library/haproxy:2.8.15 /dev/null
jstrain@jstrain:~/code/harbor$ sudo docker compose -f make/docker-compose.yml logs postgresql | grep audit_log_ext
harbor-db  | 2025-07-17 07:35:53.922 UTC [14] LOG:  execute lrupsc_1_4: INSERT INTO "audit_log_ext" ("project_id", "operation", "op_desc", "op_result", "resource_type", "resource", "username", "op_time") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"
```

After:
```
jstrain@jstrain:~/code/harbor$ sudo docker compose -f make/docker-compose.yml exec core env | grep PULL
PULL_AUDIT_LOG_DISABLE=true
PULL_TIME_UPDATE_DISABLE=true
PULL_COUNT_UPDATE_DISABLE=true
jstrain@jstrain:~/code/harbor$ crane pull localhost:8080/dockerhub/library/haproxy:2.8.15 /dev/null
jstrain@jstrain:~/code/harbor$ sudo docker compose -f make/docker-compose.yml logs postgresql | grep audit_log_ext
```
