### PR TITLE
fix: change Dependabot to weekly schedule for supply chain protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "release-note/infra"
     assignees:


### PR DESCRIPTION
## Summary
- Changes Dependabot schedule from `daily` to `weekly`

## Why
Supply chain protection. Dependabot lacks a `minimumReleaseAge` setting, so switching to weekly provides a buffer against auto-merging recently-published compromised packages. Weekly schedule ensures at least several days pass before packages are picked up.